### PR TITLE
1修复mpvue的demo登陆后，没有群组没有未读只有1v1单聊的情况下，会话列表为空的问题，解决方式与TUIKit保持一致。

### DIFF
--- a/MiniProgram/Demo/src/main.js
+++ b/MiniProgram/Demo/src/main.js
@@ -31,6 +31,13 @@ wx.$sdkAppID = SDKAPPID
 wx.$app.registerPlugin({ 'tim-upload-plugin': TIMUploadPlugin })
 registerEvents(tim)
 
+// 初始化后拉取会话列表
+tim.on(TIM.EVENT.SDK_READY, () => {
+  wx.$app.getConversationList().then((event) => {
+    store.commit('updateAllConversation', event.data.conversationList)
+  })
+})
+
 // 小程序目前对该方法没有对外暴露
 wx.onAppRoute((res) => {
   const { path, query } = res


### PR DESCRIPTION
1修复mpvue的demo登陆后，没有群组没有未读只有1v1单聊的情况下，会话列表为空的问题，解决方式与TUIKit保持一致。